### PR TITLE
fix: support for auth in callback url

### DIFF
--- a/.github/workflows/pretty.yml
+++ b/.github/workflows/pretty.yml
@@ -10,7 +10,7 @@ jobs:
       - name: Use Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: '18.x'
+          node-version: '23.x'
       - name: Install Dependencies
         run: npm ci
       - name: Run Prettier

--- a/.github/workflows/typescript.yml
+++ b/.github/workflows/typescript.yml
@@ -10,7 +10,7 @@ jobs:
       - name: Use Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: '18.x'
+          node-version: '23.x'
       - name: Install Dependencies
         run: npm ci
       - name: Run Type Check

--- a/.github/workflows/unittests.yml
+++ b/.github/workflows/unittests.yml
@@ -9,7 +9,7 @@ jobs:
       - name: Use Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: '18.x'
+          node-version: '23.x'
       - name: Install Dependencies
         run: npm ci
       - name: Run Unit Tests

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-ARG NODE_IMAGE=node:18-alpine
+ARG NODE_IMAGE=node:23-alpine
 
 # Note: This target is the one build by CI and published to dockerhub
 FROM ${NODE_IMAGE} AS without-volume-definition

--- a/README.md
+++ b/README.md
@@ -39,9 +39,7 @@ package the output of the transcoding job referenced by the message.
 | `AWS_ACCESS_KEY_ID`           | Optional AWS access key id when `PACKAGE_OUTPUT_FOLDER` is an AWS S3 bucket                                                                                                                                                           |                          |
 | `AWS_SECRET_ACCESS_KEY`       | Optional AWS secret access key when `PACKAGE_OUTPUT_FOLDER` is an AWS S3 bucket                                                                                                                                                       |                          |
 | `S3_ENDPOINT_URL`             | Optional S3 Endpoint URL when `PACKAGE_OUTPUT_FOLDER` is an S3 bucket not on AWS                                                                                                                                                      |                          |
-| `CALLBACK_URL`                | Optional callback service url. If enabled, the packager will send callbacks on packaging success or failure                                                                                                                           |                          |
-| `CALLBACK_USER`               | Optional username for authentication to the service the packager calls back to                                                                                                                                                        |                          |
-| `CALLBACK_PASSWORD`           | Optional password for authentication to the service the packager calls back to                                                                                                                                                        |                          |
+| `CALLBACK_URL`                | Optional callback service url. If enabled, the packager will send callbacks on packaging success or failure. To use baisc auth, provide the URL in the format `https://user:password@hostname/path`                                   |                          |
 
 ##### Stream key templates
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -28,7 +28,7 @@
         "@commitlint/cli": "^17.4.2",
         "@commitlint/config-conventional": "^17.4.2",
         "@types/jest": "^29.4.0",
-        "@types/node": "^18.11.18",
+        "@types/node": "^22.13.13",
         "@typescript-eslint/eslint-plugin": "^5.51.0",
         "@typescript-eslint/parser": "^5.51.0",
         "eslint": "^8.33.0",
@@ -41,7 +41,7 @@
         "typescript": "^5.0.0"
       },
       "engines": {
-        "node": ">=18.15.0"
+        "node": ">=23.3.0"
       }
     },
     "node_modules/@ampproject/remapping": {
@@ -1805,11 +1805,12 @@
       "dev": true
     },
     "node_modules/@types/node": {
-      "version": "18.19.34",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.34.tgz",
-      "integrity": "sha512-eXF4pfBNV5DAMKGbI02NnDtWrQ40hAN558/2vvS4gMpMIxaf6JmD7YjnZbq0Q9TDSSkKBamime8ewRoomHdt4g==",
+      "version": "22.13.13",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.13.13.tgz",
+      "integrity": "sha512-ClsL5nMwKaBRwPcCvH8E7+nU4GxHVx1axNvMZTFHMEfNI7oahimt26P5zjVCRrjiIWj6YFXfE1v3dEp94wLcGQ==",
+      "license": "MIT",
       "dependencies": {
-        "undici-types": "~5.26.4"
+        "undici-types": "~6.20.0"
       }
     },
     "node_modules/@types/normalize-package-data": {
@@ -6985,9 +6986,10 @@
       "integrity": "sha512-WxONCrssBM8TSPRqN5EmsjVrsv4A8X12J4ArBiiayv3DyyG3ZlIg6yysuuSYdZsVz3TKcTg2fd//Ujd4CHV1iA=="
     },
     "node_modules/undici-types": {
-      "version": "5.26.5",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
-      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA=="
+      "version": "6.20.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.20.0.tgz",
+      "integrity": "sha512-Ny6QZ2Nju20vw1SRHe3d9jVu6gJ+4e3+MMpqu7pqE5HT6WsTSlce++GQmK5UXS8mzV8DSYHrQH+Xrf2jVcuKNg==",
+      "license": "MIT"
     },
     "node_modules/universalify": {
       "version": "2.0.1",

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   },
   "license": "MIT",
   "engines": {
-    "node": ">=18.15.0"
+    "node": ">=23.3.0"
   },
   "dependencies": {
     "@eyevinn/shaka-packager-s3": "^0.6.3",
@@ -37,7 +37,7 @@
     "@commitlint/cli": "^17.4.2",
     "@commitlint/config-conventional": "^17.4.2",
     "@types/jest": "^29.4.0",
-    "@types/node": "^18.11.18",
+    "@types/node": "^22.13.13",
     "@typescript-eslint/eslint-plugin": "^5.51.0",
     "@typescript-eslint/parser": "^5.51.0",
     "eslint": "^8.33.0",

--- a/src/config.test.ts
+++ b/src/config.test.ts
@@ -1,0 +1,22 @@
+import { readCallbackConfig } from './config';
+
+describe('Test parse callback config', () => {
+  it('handles situation without auth', () => {
+    process.env.CALLBACK_URL = 'http://callback.com';
+    const conf = readCallbackConfig();
+    expect(conf).toEqual({
+      url: 'http://callback.com/',
+      user: undefined,
+      password: undefined
+    });
+  });
+  it('Handles auth in url', () => {
+    process.env.CALLBACK_URL = 'http://user:password@callback.com';
+    const conf = readCallbackConfig();
+    expect(conf).toEqual({
+      url: 'http://callback.com/',
+      user: 'user',
+      password: 'password'
+    });
+  });
+});

--- a/src/config.test.ts
+++ b/src/config.test.ts
@@ -19,4 +19,13 @@ describe('Test parse callback config', () => {
       password: 'password'
     });
   });
+  it('handles incorrect URLs', () => {
+    process.env.CALLBACK_URL = 'This is not a URL';
+    const conf = readCallbackConfig();
+    expect(conf).toEqual({
+      url: undefined,
+      user: undefined,
+      password: undefined
+    });
+  });
 });

--- a/src/config.ts
+++ b/src/config.ts
@@ -66,13 +66,13 @@ function readRedisConfig(): RedisConfig {
 
 export function readCallbackConfig(): CallbackConfig {
   const url = process.env.CALLBACK_URL
-    ? new URL(process.env.CALLBACK_URL)
-    : undefined;
+    ? URL.parse(process.env.CALLBACK_URL)
+    : null;
   const user =
     url?.username && url.username.length > 0 ? url.username : undefined;
   const password = url && url.password.length > 0 ? url.password : undefined;
   return {
-    url: url != undefined ? stripUserFromUrl(url) : undefined,
+    url: url ? stripUserFromUrl(url) : undefined,
     user: user,
     password: password
   };

--- a/src/config.ts
+++ b/src/config.ts
@@ -20,9 +20,9 @@ export interface RedisConfig {
 }
 
 export interface CallbackConfig {
-  url: string;
-  user: string;
-  password: string;
+  url?: string;
+  user?: string;
+  password?: string;
 }
 
 export interface PackagingConfig {
@@ -64,12 +64,22 @@ function readRedisConfig(): RedisConfig {
   };
 }
 
-function readCallbackConfig(): CallbackConfig {
+export function readCallbackConfig(): CallbackConfig {
+  const url = process.env.CALLBACK_URL
+    ? new URL(process.env.CALLBACK_URL)
+    : undefined;
+  const user =
+    url?.username && url.username.length > 0 ? url.username : undefined;
+  const password = url && url.password.length > 0 ? url.password : undefined;
   return {
-    url: process.env.CALLBACK_URL || '',
-    user: process.env.CALLBACK_USER || '',
-    password: process.env.CALLBACK_PASSWORD || ''
+    url: url != undefined ? stripUserFromUrl(url) : undefined,
+    user: user,
+    password: password
   };
+}
+
+function stripUserFromUrl(url: URL): string {
+  return `${url.protocol}//${url.host}${url.pathname}`;
 }
 
 function readPackagingConfig(): PackagingConfig {


### PR DESCRIPTION
- Changes the API for callback URLs. remove `CALLBACK_USER`, `CALLBACK_PASSWORD` env vars, read credentials from URL instead.
Signed-off-by: Fredrik Lundkvist <fredrik.lundkvist@eyevinn.se>
