### PR TITLE
fix: double slashes in URLs

### DIFF
--- a/src/callbackListener.ts
+++ b/src/callbackListener.ts
@@ -16,7 +16,10 @@ export class CallbackListener implements PackageListener {
       this.authUser,
       this.authPassword
     );
-    const fetchUrl = new URL('packagerCallback/success', this.url);
+    const fetchUrl = new URL(
+      PathUtils.join(this.url.pathname, 'packagerCallback/success'),
+      this.url
+    );
     const response = await fetch(fetchUrl.toString(), {
       method: 'POST',
       headers: headers,
@@ -39,7 +42,10 @@ export class CallbackListener implements PackageListener {
       this.authUser,
       this.authPassword
     );
-    const fetchUrl = new URL('packagerCallback/failure', this.url);
+    const fetchUrl = new URL(
+      PathUtils.join(this.url.pathname, 'packagerCallback/failure'),
+      this.url
+    );
     await fetch(fetchUrl.toString(), {
       method: 'POST',
       headers: headers,

--- a/src/callbackListener.ts
+++ b/src/callbackListener.ts
@@ -1,10 +1,11 @@
 import { Context } from '@osaas/client-core';
 import logger from './logger';
 import { PackageListener } from './packageListener';
+import { default as PathUtils } from 'path';
 
 export class CallbackListener implements PackageListener {
   constructor(
-    private url: string,
+    private url: URL,
     private authUser?: string,
     private authPassword?: string,
     private oscAccessToken?: string
@@ -15,7 +16,11 @@ export class CallbackListener implements PackageListener {
       this.authUser,
       this.authPassword
     );
-    const response = await fetch(`${this.url}/packagerCallback/success`, {
+    const fetchUrl = new URL(
+      PathUtils.join(this.url.pathname, 'packagerCallback/success'),
+      this.url
+    );
+    const response = await fetch(fetchUrl.toString(), {
       method: 'POST',
       headers: headers,
       body: JSON.stringify({
@@ -37,7 +42,11 @@ export class CallbackListener implements PackageListener {
       this.authUser,
       this.authPassword
     );
-    await fetch(`${this.url}/packagerCallback/failure`, {
+    const fetchUrl = new URL(
+      PathUtils.join(this.url.pathname, 'packagerCallback/failure'),
+      this.url
+    );
+    await fetch(fetchUrl.toString(), {
       method: 'POST',
       headers: headers,
       body: JSON.stringify({

--- a/src/callbackListener.ts
+++ b/src/callbackListener.ts
@@ -16,10 +16,7 @@ export class CallbackListener implements PackageListener {
       this.authUser,
       this.authPassword
     );
-    const fetchUrl = new URL(
-      PathUtils.join(this.url.pathname, 'packagerCallback/success'),
-      this.url
-    );
+    const fetchUrl = new URL('packagerCallback/success', this.url);
     const response = await fetch(fetchUrl.toString(), {
       method: 'POST',
       headers: headers,
@@ -42,10 +39,7 @@ export class CallbackListener implements PackageListener {
       this.authUser,
       this.authPassword
     );
-    const fetchUrl = new URL(
-      PathUtils.join(this.url.pathname, 'packagerCallback/failure'),
-      this.url
-    );
+    const fetchUrl = new URL('packagerCallback/failure', this.url);
     await fetch(fetchUrl.toString(), {
       method: 'POST',
       headers: headers,

--- a/src/config.test.ts
+++ b/src/config.test.ts
@@ -4,28 +4,26 @@ describe('Test parse callback config', () => {
   it('handles situation without auth', () => {
     process.env.CALLBACK_URL = 'http://callback.com';
     const conf = readCallbackConfig();
-    expect(conf).toEqual({
-      url: 'http://callback.com/',
-      user: undefined,
-      password: undefined
-    });
+    expect(conf.url?.toString()).toEqual('http://callback.com/');
+    expect(conf.user).toBeUndefined;
+    expect(conf.password).toBeUndefined;
   });
   it('Handles auth in url', () => {
     process.env.CALLBACK_URL = 'http://user:password@callback.com';
     const conf = readCallbackConfig();
-    expect(conf).toEqual({
-      url: 'http://callback.com/',
-      user: 'user',
-      password: 'password'
-    });
+    expect(conf.user).toEqual('user');
+    expect(conf.password).toEqual('password');
+    expect(conf.url?.toString()).toEqual('http://callback.com/');
   });
   it('handles incorrect URLs', () => {
     process.env.CALLBACK_URL = 'This is not a URL';
     const conf = readCallbackConfig();
-    expect(conf).toEqual({
-      url: undefined,
-      user: undefined,
-      password: undefined
-    });
+    expect(conf.password).toBeUndefined;
+    expect(conf.user).toBeUndefined;
+    expect(conf.url).toBeUndefined;
+  });
+  it('url', () => {
+    const x = URL.parse('http://callback.com');
+    expect(x).not.toBeNull;
   });
 });

--- a/src/config.ts
+++ b/src/config.ts
@@ -20,7 +20,7 @@ export interface RedisConfig {
 }
 
 export interface CallbackConfig {
-  url?: string;
+  url?: URL;
   user?: string;
   password?: string;
 }
@@ -71,15 +71,19 @@ export function readCallbackConfig(): CallbackConfig {
   const user =
     url?.username && url.username.length > 0 ? url.username : undefined;
   const password = url && url.password.length > 0 ? url.password : undefined;
-  return {
-    url: url ? stripUserFromUrl(url) : undefined,
-    user: user,
-    password: password
-  };
+  const urlStr = url ? stripUserFromUrl(url) : undefined;
+  if (urlStr) {
+    return {
+      url: urlStr,
+      user: user,
+      password: password
+    };
+  }
+  return {};
 }
 
-function stripUserFromUrl(url: URL): string {
-  return `${url.protocol}//${url.host}${url.pathname}`;
+function stripUserFromUrl(url: URL): URL | null {
+  return URL.parse(`${url.protocol}//${url.host}${url.pathname}`);
 }
 
 function readPackagingConfig(): PackagingConfig {


### PR DESCRIPTION
- Switch to using URL datatype for creating callback URLs instead of string concat
Signed-off-by: Fredrik Lundkvist <fredrik.lundkvist@eyevinn.se>
