### PR TITLE
feat: send output path on successful package

### DIFF
--- a/src/callbackListener.ts
+++ b/src/callbackListener.ts
@@ -11,7 +11,11 @@ export class CallbackListener implements PackageListener {
     private oscAccessToken?: string
   ) {}
 
-  async onPackageDone?(jobUrl: string, jobId: string): Promise<void> {
+  async onPackageDone?(
+    jobUrl: string,
+    jobId: string,
+    outputPath?: string
+  ): Promise<void> {
     const headers = await this.generateHeaders(
       this.authUser,
       this.authPassword
@@ -20,13 +24,17 @@ export class CallbackListener implements PackageListener {
       PathUtils.join(this.url.pathname, 'packagerCallback/success'),
       this.url
     );
+    let body: { url: string; jobId: string; outputPath?: string } = {
+      url: jobUrl,
+      jobId: jobId
+    };
+    if (outputPath) {
+      body = { ...body, outputPath: outputPath };
+    }
     const response = await fetch(fetchUrl.toString(), {
       method: 'POST',
       headers: headers,
-      body: JSON.stringify({
-        url: jobUrl,
-        jobId: jobId
-      })
+      body: JSON.stringify(body)
     });
     if (!response.ok) {
       logger.error(

--- a/src/encorePackager.ts
+++ b/src/encorePackager.ts
@@ -37,7 +37,7 @@ const ENCORE_BASIC_AUTH_USER = 'user';
 export class EncorePackager {
   constructor(private config: PackagingConfig) {}
 
-  async package(jobUrl: string) {
+  async package(jobUrl: string): Promise<string> {
     const job = await this.getEncoreJob(jobUrl);
     const inputs = parseInputsFromEncoreJob(job, this.config.streamKeysConfig);
     let serviceAccessToken = undefined;
@@ -61,6 +61,13 @@ export class EncorePackager {
       packageFormatOptions
     } as PackageOptions);
     logger.info(`Finished packaging of job ${job.id} to output folder ${dest}`);
+    if (URL.canParse(dest)) {
+      const parsed = URL.parse(dest);
+      if (parsed) {
+        return parsed.pathname;
+      }
+    }
+    return dest;
   }
 
   getPackageDestination(job: EncoreJob) {

--- a/src/packageListener.ts
+++ b/src/packageListener.ts
@@ -1,5 +1,5 @@
 export interface PackageListener {
-  onPackageDone?(jobUrl: string, jobId: string): void;
+  onPackageDone?(jobUrl: string, jobId: string, outputPath?: string): void;
   //eslint-disable-next-line @typescript-eslint/no-explicit-any
   onPackageFail?(message: string, err: any): void;
   onPackageStart?(jobUrl: string, jobId: string): void;


### PR DESCRIPTION
In some setups, callback listeners may need to know where the output from the packaging job is stored; due to the flexibility of the packager, guessing or hard-coding where the files are expected to be feels like a bad idea.
This PR adds a string return value to `doPackage`, which can then be passed on to a packagelistener; an example of how that data can be handled is shown in `callbackListener.ts`.
Signed-off-by: Fredrik Lundkvist <fredrik.lundkvist@eyevinn.se>
